### PR TITLE
Bugfix: Reset button appearance in webkit browsers

### DIFF
--- a/style.css
+++ b/style.css
@@ -74,6 +74,7 @@ input.button {
     text-align: center;
     line-height: 16px;
     border: none;
+    -webkit-appearance: none;
 }
 
 input.button:hover {


### PR DESCRIPTION
Safari and other webkit browsers need a little more to reset their appearance. Fixes #6 
Demo:
<img width="298" alt="screen shot 2018-05-22 at 12 23 44" src="https://user-images.githubusercontent.com/1177460/40359573-24faa858-5dbb-11e8-8edb-4fb0e319bb0a.png">
