### PR TITLE
Allow people to close brief modals by clicking outside them

### DIFF
--- a/src/js/Routing.js
+++ b/src/js/Routing.js
@@ -13,6 +13,25 @@ class Routing {
     }
   }
 
+  handlClickOutsideBrief = e => {
+    const brief = document.querySelector('.brief');
+    if (brief) {
+      // add event listener to close brief if clicking outside it
+      let targetElement = e.target; // clicked element
+      do {
+        if (targetElement == brief) {
+          // we are already on the brief - yay! no action needed - stop here.
+          return;
+        }
+        // Go up the DOM from where we clicked.
+        targetElement = targetElement.parentNode;
+      } while (targetElement);
+
+      // clicked outside the brief! let's close it.
+      this.history.goBack();
+    }
+  }
+
   bindRoutes = () => {
     // sniff all internal links for routing
     on('click', '.js-has-routing .js-route', e => {
@@ -50,6 +69,8 @@ class Routing {
 
     // bind the escape key
     document.addEventListener('keydown', this.handleEscape);
+    // bind checking for clicks outside the brief modal
+    document.addEventListener('click', this.handlClickOutsideBrief);
 
     // load route
     fetch(url)
@@ -100,6 +121,8 @@ class Routing {
 
     // unbind the escape key
     document.removeEventListener('keydown', this.handleEscape);
+    // unbind checking for clicks outside the brief modal
+    document.removeEventListener('click', this.handlClickOutsideBrief);
   }
 
   constructor() {

--- a/src/js/Routing.js
+++ b/src/js/Routing.js
@@ -13,14 +13,15 @@ class Routing {
     }
   }
 
-  handlClickOutsideBrief = e => {
+  handleClickOutsideBriefOrMastHead = e => {
     const brief = document.querySelector('.brief');
+    const masthead = document.querySelector('.masthead');
     if (brief) {
       // add event listener to close brief if clicking outside it
       let targetElement = e.target; // clicked element
       do {
-        if (targetElement == brief) {
-          // we are already on the brief - yay! no action needed - stop here.
+        if (targetElement == masthead || targetElement == brief) {
+          // we are already on the brief  or masthead - yay! no action needed - stop here.
           return;
         }
         // Go up the DOM from where we clicked.
@@ -69,8 +70,8 @@ class Routing {
 
     // bind the escape key
     document.addEventListener('keydown', this.handleEscape);
-    // bind checking for clicks outside the brief modal
-    document.addEventListener('click', this.handlClickOutsideBrief);
+    // bind checking for clicks outside the brief modal or masthead
+    document.addEventListener('click', this.handleClickOutsideBriefOrMastHead);
 
     // load route
     fetch(url)
@@ -122,7 +123,7 @@ class Routing {
     // unbind the escape key
     document.removeEventListener('keydown', this.handleEscape);
     // unbind checking for clicks outside the brief modal
-    document.removeEventListener('click', this.handlClickOutsideBrief);
+    document.removeEventListener('click', this.handleClickOutsideBriefOrMastHead);
   }
 
   constructor() {


### PR DESCRIPTION
Hey Luke,

Really love the DesignChallenge site - thank you for making this!

One small enhancement I thought would be nice would be to add the ability to click outside an open design brief modal box to close it - quite a common UX practice (in addition to having a close link, which you already have). This is really useful when browsing on bigger screens.

I've added a small bit of code to check where people click, and close modal if they have clicked outside. I've tested it on desktop, and made sure it doesn't interfere with the mobile view or the view if you go direct to a brief. Tested on Chrome, Safari and Firefox.

Unsure how open you are to people contributing (have never contributed to anything before like this!) but thought I'd try and help out.

HTH,
Al

![2018-05-14-designchallenge](https://user-images.githubusercontent.com/858646/41428502-306f8a6a-7002-11e8-9702-ae42285d3c2b.gif)

